### PR TITLE
Adding more module features

### DIFF
--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -101,11 +101,11 @@ module.exports = function(grunt) {
 
         for (var directive in data.options) {
             if (Array.isArray(data.options[directive])) {
-                command += ' --' + directive + ' ' + data.options[directive].join(' --' + directive + ' ');
+                command += ' --' + directive + '=' + data.options[directive].join(' --' + directive + '=');
             } else if (data.options[directive] === undefined || data.options[directive] === null) {
                 command += ' --' + directive;
             } else {
-                command += ' --' + directive + ' "' + String(data.options[directive]) + '"';
+                command += ' --' + directive + '="' + String(data.options[directive]) + '"';
             }
         }
 

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
         //case : js parameter passed (no module then)
         if(data.js && data.js.length && data.js.length>0) {
 
-            command += ' --js "' + data.js.join('" --js "') + '"';
+            command += ' --js="' + data.js.join('" --js="') + '"';
             if (data.jsOutputFile) {
                 if (!grunt.file.isPathAbsolute(data.jsOutputFile)) {
                     data.jsOutputFile = path.resolve('./') + '/' + data.jsOutputFile;
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
 
         if (data.externs) {
             data.externs = grunt.file.expand(data.externs);
-            command += ' --externs ' + data.externs.join(' --externs ');
+            command += ' --externs=' + data.externs.join(' --externs=');
 
             if (!data.externs.length) {
                 delete data.externs;
@@ -77,20 +77,21 @@ module.exports = function(grunt) {
         //adding module compilation support
         if(data.modules){
             if(data.modules.output_path_prefix){
-                command += ' --module_output_path_prefix ' + data.modules.output_path_prefix+' ';
+                command += ' --module_output_path_prefix=' + data.modules.output_path_prefix+' ';
             }
             if(data.modules.definitions){
                 for(var module in data.modules.definitions){
                     for(var fileIndex = 0;fileIndex<data.modules.definitions[module].files.length;fileIndex++){
-                        command += ' --js ' +data.modules.definitions[module].files[fileIndex]+' ';
+                        command += ' --js=' + data.modules.definitions[module].files[fileIndex] + ' ';
                     }
-                    command += ' --module '+module+':'+data.modules.definitions[module].files.length;
+                    command += ' --module ' + module + ':' +
+					    (data.modules.definitions[module].autoLength ? 'auto' : data.modules.definitions[module].files.length);
                     if(data.modules.definitions[module].dependencies && data.modules.definitions[module].dependencies.length>0){
-                        command+=':'+data.modules.definitions[module].dependencies.join(',');
+                        command += ':' + data.modules.definitions[module].dependencies.join(',');
                     }
-                    command+= ' ';
+                    command += ' ';
                     if(data.modules.definitions[module].wrapper){
-                        command+='--module_wrapper '+module+':"'+data.modules.definitions[module].wrapper+'" ';
+                        command += '--module_wrapper ' + module + ':"' + data.modules.definitions[module].wrapper + '" ';
                     }
                 }
 

--- a/tasks/closure-compiler.js
+++ b/tasks/closure-compiler.js
@@ -119,8 +119,6 @@ module.exports = function(grunt) {
             }
         }
 
-console.log(command);
-
         // Minify WebGraph class.
         exec(command, { maxBuffer: data.maxBuffer * 1024, cwd: data.cwd }, function(err, stdout, stderr) {
             if (err) {


### PR DESCRIPTION
I'm a Closure-compiler project maintainer and came across your PR/fork. Modules aren't used widely, but are extremely powerful. I am using your fork for a project of mine and needed to make a few tweaks.
1. Closure-compiler supports minmatch globs for input sources. This gets around command line length limits on windows. To support this, the first module may now specify a size of "auto" rather than an exact file count.
2. When using minmatch globs, the compiler can be picky about the source and needs the "=" sign following the `--js` flag.
